### PR TITLE
Conflict if I do git submodule --merge

### DIFF
--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -1,0 +1,6 @@
+# pvCommonCPP Release Notes
+
+## Release 4.2.0
+
+The Boost header files are now only installed for VxWorks target architectures, since they are only essential for that OS. This prevents clashes with sofware that has been built with a different version of Boost.
+

--- a/documentation/RELEASE_NOTES.md
+++ b/documentation/RELEASE_NOTES.md
@@ -1,6 +1,13 @@
 # pvCommonCPP Release Notes
 
+## Release 4.2.3
+
+The `mb.h` header has been updated to build properly against EPICS Base
+versions prior to 3.15.0.1.
+
 ## Release 4.2.0
 
-The Boost header files are now only installed for VxWorks target architectures, since they are only essential for that OS. This prevents clashes with sofware that has been built with a different version of Boost.
+The Boost header files are now only installed for VxWorks target architectures,
+since they are only essential for that OS. This prevents clashes with sofware
+that has been built with a different version of Boost.
 

--- a/documentation/pvCommonCPP.html
+++ b/documentation/pvCommonCPP.html
@@ -19,11 +19,12 @@
 <div class="head">
 <h1>EPICS pvCommonCPP</h1>
 
-<h2 class="nocount">Release 4.2.0, 19-Jul-2016</h2>
+<h2 class="nocount">Release 4.2.2, 25-Aug-2016</h2>
 
   <dl>
     <dt>Editors:</dt>
     <dd>Matej Sekoranja, Cosylab</dd>
+    <dd>Andrew Johnson, Argonne</dd>
   </dl>
 
 <hr />

--- a/documentation/pvCommonCPP.html
+++ b/documentation/pvCommonCPP.html
@@ -19,7 +19,7 @@
 <div class="head">
 <h1>EPICS pvCommonCPP</h1>
 
-<h2 class="nocount">Release 4.2.2, 25-Aug-2016</h2>
+<h2 class="nocount">Release 4.2.3, 18-Dec-2017</h2>
 
   <dl>
     <dt>Editors:</dt>

--- a/jenkins/cloudbees_doc
+++ b/jenkins/cloudbees_doc
@@ -65,10 +65,9 @@ doxygen
 ###########################################
 # Publish
 
-if [ "${PUBLISH}" != "DONT" ]; then
+if [ "${PUBLISH}" != "NO" ]; then
     # Upload explicit dummy to ensure target directory exists
     echo "Created by CloudBees Jenkins upload job. Should be deleted as part of the job." > DUMMY
     rsync -q -e ssh DUMMY epics-jenkins@web.sourceforge.net:/home/project-web/epics-pvdata/htdocs/docbuild/pvCommonCPP/${PUBLISH}/
-
     rsync -aqP --delete -e ssh documentation epics-jenkins@web.sourceforge.net:/home/project-web/epics-pvdata/htdocs/docbuild/pvCommonCPP/${PUBLISH}/
 fi

--- a/mbSrc/Makefile
+++ b/mbSrc/Makefile
@@ -12,7 +12,7 @@ INC += mb.h
 
 LIBRARY = pvMB
 
-SHRLIB_VERSION = 4.2.0
+SHRLIB_VERSION ?= 4.2.0
 
 pvMB_SRCS += mb.cpp
 pvMB_LIBS = Com

--- a/mbSrc/Makefile
+++ b/mbSrc/Makefile
@@ -12,7 +12,7 @@ INC += mb.h
 
 LIBRARY = pvMB
 
-SHRLIB_VERSION ?= 4.2.0
+SHRLIB_VERSION ?= 4.2.2
 
 pvMB_SRCS += mb.cpp
 pvMB_LIBS = Com

--- a/mbSrc/Makefile
+++ b/mbSrc/Makefile
@@ -12,7 +12,7 @@ INC += mb.h
 
 LIBRARY = pvMB
 
-SHRLIB_VERSION ?= 4.2.2
+SHRLIB_VERSION ?= 4.2.3
 
 pvMB_SRCS += mb.cpp
 pvMB_LIBS = Com


### PR DESCRIPTION
Hi, 

  I have the following issues, if I do the git submodule ... --merge. It may be there are somethings missing in git repository. Please review them and let me know.


```
git submodule update --init --recursive pvCommonCPP/.
Cloning into 'pvCommonCPP'...
remote: Counting objects: 3844, done.
remote: Total 3844 (delta 0), reused 0 (delta 0), pack-reused 3844
Receiving objects: 100% (3844/3844), 4.68 MiB | 2.81 MiB/s, done.
Resolving deltas: 100% (2368/2368), done.
Checking connectivity... done.
Submodule path 'pvCommonCPP': checked out 'd0bbf47ce449f80f5c6d3e262cf6f924753aa457'
git submodule update --remote --merge pvCommonCPP/
Auto-merging mbSrc/Makefile
CONFLICT (content): Merge conflict in mbSrc/Makefile
Automatic merge failed; fix conflicts and then commit the result.
Unable to merge '26bebc9dcef3bbf5afad74cf7e8a4e6358c15a04' in submodule path 'pvCommonCPP'
```